### PR TITLE
removed fail-safe for coverage tests on unittests

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,6 +22,7 @@ jobs:
         echo "MONGO_URI=mongo_db_key" >> $GITHUB_ENV
         echo "PINECONE_KEY=your_pinecone_key" >> $GITHUB_ENV
         echo "PINECONE_ENV=your_pinecone_env" >> $GITHUB_ENV
+        echo "OPENAI_API_KEY=your_openai_key" >> $GITHUB_ENV
         echo "ENVIRONMENT=TEST" >> $GITHUB_ENV
 
     - name: Install dependencies
@@ -32,5 +33,5 @@ jobs:
 
     - name: Run unittests with coverage
       run: |
-        coverage run -m unittest discover || true
-        coverage report -m || true
+        coverage run -m unittest discover
+        coverage report -m

--- a/db/tests/test_vectordb.py
+++ b/db/tests/test_vectordb.py
@@ -1,24 +1,28 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from db.vectordb import batch_upload_vectors, upload_vectors, query, delete
+from db.vectordb import (
+    batch_upload_vectors,
+    upload_vectors,
+    query,
+    delete,
+    init_pinecone,
+)
 from db.db_types import PCEmbeddingData, PCEmbeddingMetadata, PCQueryResults
-import pinecone
 
 
 class TestVectorDB(unittest.TestCase):
     @patch("db.vectordb.pinecone.Index")
-    def test_upload_vectors(self, mock_index: MagicMock) -> None:
-        # Arrange
-        metadata: PCEmbeddingMetadata = {"category": "test_category", "chat_id": 12345}
+    def test_upload_vectors(self, mock_index_class: MagicMock) -> None:
+        metadata: PCEmbeddingMetadata = PCEmbeddingMetadata(
+            category="test_category", chat_id=12345
+        )
         mock_embeddings: list[PCEmbeddingData] = [
             PCEmbeddingData(id="1", values=[0.1, 0.2], metadata=metadata)
         ]
+        mock_index = mock_index_class.return_value
         mock_index.upsert = MagicMock()
 
-        # Act
         upload_vectors(mock_embeddings, mock_index)
-
-        # Assert
         mock_index.upsert.assert_called_once_with(vectors=mock_embeddings)
 
     @patch("db.vectordb.init_pinecone", return_value=MagicMock())
@@ -26,45 +30,48 @@ class TestVectorDB(unittest.TestCase):
     def test_batch_upload_vectors(
         self, mock_upload_vectors: MagicMock, mock_init_pinecone: MagicMock
     ) -> None:
-        # Arrange
-        metadata: PCEmbeddingMetadata = {"category": "test_category", "chat_id": 12345}
+        metadata: PCEmbeddingMetadata = PCEmbeddingMetadata(
+            category="test_category", chat_id=12345
+        )
         mock_embeddings: list[PCEmbeddingData] = [
             PCEmbeddingData(id="1", values=[0.1, 0.2], metadata=metadata)
         ] * 250
         mock_index = MagicMock()
 
-        # Act
         batch_upload_vectors(mock_index, mock_embeddings)
-
-        # Assert
         self.assertEqual(mock_upload_vectors.call_count, 3)
         mock_init_pinecone.assert_not_called()
 
     @patch("db.vectordb.pinecone.Index")
-    def test_upload_vectors(self, mock_index_class: MagicMock) -> None:
-        # Mock the pinecone.Index instance
+    def test_query(self, mock_index_class: MagicMock) -> None:
+        mock_response = {"matches": [], "total": 0, "namespace": "test"}
         mock_index = mock_index_class.return_value
-        mock_index.upsert = MagicMock()
+        mock_index.query.return_value = mock_response
 
-        # Arrange
-        metadata: PCEmbeddingMetadata = {"category": "test_category", "chat_id": 12345}
-        mock_embeddings: list[PCEmbeddingData] = [
-            PCEmbeddingData(id="1", values=[0.1, 0.2], metadata=metadata)
-        ]
-
-        # Act
-        upload_vectors(mock_embeddings, mock_index)
-
-        # Assert
-        mock_index.upsert.assert_called_once_with(vectors=mock_embeddings)
-
-    @patch("db.vectordb.pinecone.Index")
-    def test_query(self, mock_index: MagicMock) -> None:
-        mock_index.query.return_value = {"matches": [], "total": 0, "namespace": "test"}
-        result: PCQueryResults = query(mock_index, [0.1, 0.2])
+        result = query(12345, [0.1, 0.2], 5, mock_index)
         self.assertIsInstance(result, dict)
+        self.assertEqual(result, mock_response)
+        mock_index.query.assert_called_once_with(
+            vector=[0.1, 0.2], top_k=5, filter={"chat_id": {"$eq": 12345}}
+        )
 
     @patch("db.vectordb.pinecone")
     def test_delete(self, mock_pinecone: MagicMock) -> None:
         delete("test_index")
         mock_pinecone.delete_index.assert_called_once_with(name="test_index")
+
+    @patch("db.vectordb.os.getenv")
+    @patch("db.vectordb.pinecone")
+    def test_init_pinecone(
+        self, mock_pinecone: MagicMock, mock_getenv: MagicMock
+    ) -> None:
+        mock_getenv.return_value = "TEST"
+        self.assertIsNone(init_pinecone())
+
+        mock_getenv.return_value = "PROD"
+        mock_pinecone.init = MagicMock()
+        mock_pinecone.Index.return_value = MagicMock()
+        mock_pinecone.list_indexes.return_value = ["test_index"]
+
+        self.assertIsNotNone(init_pinecone())
+        mock_pinecone.init.assert_called()


### PR DESCRIPTION
removed fail-safe for unit tests in GitHub Actions to ensure that tests are actually passing: 
- added mock OPENAI_KEY to unittest environment to ensure previous failing test passes.
- removed the "| | true" I added to make the pipeline successfully complete by default previously
- fixed failing test in test_vectordb

review: @L-iet @majeczzzka 